### PR TITLE
Fix duration

### DIFF
--- a/course.pl
+++ b/course.pl
@@ -98,7 +98,7 @@ inTerm(Course, Term, [Section | Sections]) :- section(Section, course, Course2),
 
 % true if intervals is all intervals in half hour permutations between the start and end times that last duration long.
 permuteIntervals(interval(_, _, Start, End), Duration, []) :- duration(Start, NewEnd, Duration), strictlyBefore(End, NewEnd).
-permuteIntervals(interval(Term, Day, Start, End), Duration, [interval(Term, Day, Start, NewEnd) | Intervals]) :- duration(Start, NewEnd, Duration), duration(Start, NewStart, time(0, 30)), permuteIntervals(interval(Term, Day, NewStart, End), Duration, Intervals).
+permuteIntervals(interval(Term, Day, Start, End), Duration, [interval(Term, Day, Start, NewEnd) | Intervals]) :- duration(Start, NewEnd, Duration), before(NewEnd, End), duration(Start, NewStart, time(0, 30)), permuteIntervals(interval(Term, Day, NewStart, End), Duration, Intervals).
 
 % true if the duration between start and end time is Duration, (works when we know duration but not end time)
 duration(time(StartHour, StartMinute), time(EndHour, EndMinute), time(DurationHour, DurationMinute)) :- (DurationMinute + StartMinute < 60)

--- a/course.pl
+++ b/course.pl
@@ -100,9 +100,10 @@ inTerm(Course, Term, [Section | Sections]) :- section(Section, course, Course2),
 permuteIntervals(interval(_, _, Start, End), Duration, []) :- duration(Start, NewEnd, Duration), strictlyBefore(End, NewEnd).
 permuteIntervals(interval(Term, Day, Start, End), Duration, [interval(Term, Day, Start, NewEnd) | Intervals]) :- duration(Start, NewEnd, Duration), duration(Start, NewStart, time(0, 30)), permuteIntervals(interval(Term, Day, NewStart, End), Duration, Intervals).
 
-% true if the duration between start and end time is Duration
-duration(time(StartHour, StartMinute), time(EndHour, EndMinute), time(DurationHour, DurationMinute)) :- StartMinute =< EndMinute, DurationHour is EndHour - StartHour, DurationMinute is EndMinute - StartMinute.
-duration(time(StartHour, StartMinute), time(EndHour, EndMinute), time(DurationHour, DurationMinute)) :- StartMinute > EndMinute, DurationHour is EndHour - StartHour - 1, DurationMinute is EndMinute - StartMinute + 60.
+% true if the duration between start and end time is Duration, (works when we know duration but not end time)
+duration(time(StartHour, StartMinute), time(EndHour, EndMinute), time(DurationHour, DurationMinute)) :- (DurationMinute + StartMinute < 60)
+    -> EndHour is StartHour + DurationHour, EndMinute is DurationMinute + StartMinute
+	; EndHour is DurationHour + StartHour + 1, EndMinute is DurationMinute + StartMinute - 60.
 
 % true if one interval in given intervals doesn't collide with given sections. (ormap)
 oneIntervalFree([Interval | _], Sections) :- noCollide2(Interval, Sections).


### PR DESCRIPTION
Assumes that we know duration and start time rather than start and end time. I cannot figure out a way that works where we can assume that we know none of the times, which is frustrating.

Fixes #21 